### PR TITLE
Fix #165.

### DIFF
--- a/src/me/neatmonster/spacebukkit/actions/ServerActions.java
+++ b/src/me/neatmonster/spacebukkit/actions/ServerActions.java
@@ -426,9 +426,10 @@ public class ServerActions implements ActionHandler {
             pluginInformations.put("IsEnabled", plugin.isEnabled());
             pluginInformations.put("Commands", plugin.getDescription().getCommands());
             pluginInformations.put("Depend", plugin.getDescription().getDepend());
-            try {
-                pluginInformations.put("DataFolder", plugin.getDataFolder().getPath());                
-            } catch (NullPointerException e) {
+            File dataFolder = plugin.getDataFolder();
+            if (dataFolder != null) {
+                pluginInformations.put("DataFolder", dataFolder.getPath());
+            } else {
                 pluginInformations.put("DataFolder", "NONE");
             }
             pluginInformations.put("SoftDepend", plugin.getDescription().getSoftDepend());

--- a/src/me/neatmonster/spacebukkit/actions/ServerActions.java
+++ b/src/me/neatmonster/spacebukkit/actions/ServerActions.java
@@ -426,7 +426,11 @@ public class ServerActions implements ActionHandler {
             pluginInformations.put("IsEnabled", plugin.isEnabled());
             pluginInformations.put("Commands", plugin.getDescription().getCommands());
             pluginInformations.put("Depend", plugin.getDescription().getDepend());
-            pluginInformations.put("DataFolder", plugin.getDataFolder().getPath());
+            try {
+                pluginInformations.put("DataFolder", plugin.getDataFolder().getPath());                
+            } catch (NullPointerException e) {
+                pluginInformations.put("DataFolder", "NONE");
+            }
             pluginInformations.put("SoftDepend", plugin.getDescription().getSoftDepend());
             pluginInformations.put("Authors", plugin.getDescription().getAuthors());
             pluginInformations.put("Description", plugin.getDescription().getDescription());

--- a/src/me/neatmonster/spacebukkit/plugins/PluginsManager.java
+++ b/src/me/neatmonster/spacebukkit/plugins/PluginsManager.java
@@ -41,7 +41,7 @@ public class PluginsManager {
      * @return Jar File the plugin's code is contained in
      */
     public static File getJAR(final Plugin plugin) {
-        if (!plugin.getPluginLoader() instanceof JavaPluginLoader){
+        if (!(plugin.getPluginLoader() instanceof JavaPluginLoader)){
     		return null;
     	}
         Class<?> currentClass = plugin.getClass();

--- a/src/me/neatmonster/spacebukkit/plugins/PluginsManager.java
+++ b/src/me/neatmonster/spacebukkit/plugins/PluginsManager.java
@@ -25,7 +25,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
-
+import org.bukkit.plugin.java.JavaPluginLoader;
 /**
  * Manages Plugins and interacts with BukGet
  */
@@ -41,7 +41,7 @@ public class PluginsManager {
      * @return Jar File the plugin's code is contained in
      */
     public static File getJAR(final Plugin plugin) {
-        if (!plugin.getPluginLoader().getClass().equals(JavaPluginLoader.class)){
+        if (!plugin.getPluginLoader() instanceof JavaPluginLoader){
     		return null;
     	}
         Class<?> currentClass = plugin.getClass();

--- a/src/me/neatmonster/spacebukkit/plugins/PluginsManager.java
+++ b/src/me/neatmonster/spacebukkit/plugins/PluginsManager.java
@@ -41,6 +41,9 @@ public class PluginsManager {
      * @return Jar File the plugin's code is contained in
      */
     public static File getJAR(final Plugin plugin) {
+        if (!plugin.getPluginLoader().getClass().equals(JavaPluginLoader.class)){
+    		return null;
+    	}
         Class<?> currentClass = plugin.getClass();
         while (!(currentClass.equals(JavaPlugin.class))) {
             currentClass = currentClass.getSuperclass();


### PR DESCRIPTION
In function GetJAR, check if the Plugin's PluginLoader is the 
JavaPluginLoader class. If it isn't, return null. 
This way, if there is custom plugin loaders installed (Such as PythonPluginLoader (http://dev.bukkit.org/server-mods/Python-Plugin-Loader/ ) or _maybe_ tekkit/modloadermp (untested)), there will be no errors and the Plugins page will load correctly.
